### PR TITLE
"Run In Terminal Emulator" on Linux

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,7 @@ directory as the current working directory.`,
 		window, and show the output to that window.`,
 		type: 'string',
 		default: 'None',
-		enum: ['None', 'CMD (Windows)', 'iTerm2'],
+		enum: ['None', 'CMD (Windows)', 'iTerm2', 'uxterm (Linux)', 'Gnome terminal'],
 		order: 3,
 	},
 	disableToolbarButton: {
@@ -113,6 +113,26 @@ function run() {
 			end tell`;
 			child.stdin.write(apple_script);
 			child.stdin.end();
+			break;
+		case 'uxterm (Linux)':
+			child_process.exec(`uxterm -e "${command}"`, {cwd: dirs[0].getPath()}, (err, stdout, stderr) => {
+				if(err) {
+					var message = stderr.toString();
+					atom.notifications.addError('Error running uxterm.', {
+						detail: message
+					});
+				}
+			});
+			break;
+		case 'Gnome terminal':
+			child_process.exec(`gnome-terminal -x sh -c "${command}"`, {cwd: dirs[0].getPath()}, (err, stdout, stderr) => {
+				if(err) {
+					var message = stderr.toString();
+					atom.notifications.addError('Error running Gnome terminal.', {
+						detail: message
+					});
+				}
+			});
 			break;
 		default:
 			atom.notifications.addError(`Unsupported terminal emulator ${terminalEmulator}.`);


### PR DESCRIPTION
What it doesn't do:
Errors inside terminal are not catchable, so the only errors are related to a non-existent uxterm or gnome-terminal. That's why the error notification title was changed.