### PR TITLE
Fix error reporting on windows

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,7 +75,7 @@ function run() {
 		case 'None':
 			child_process.exec(command, {cwd: dirs[0].getPath()}, (err, stdout, stderr) => {
 				if(err) {
-					var message = stderr.toString();
+					var message = stdout.toString();
 					if (err.code == 127) message = "LOVE executable not found. Try setting the PATH in the love-ide settings menu.";
 					atom.notifications.addError('Error running LOVE.', {
 						detail: message


### PR DESCRIPTION
I've found that the error output doesn't actually work for windows, either via `lovec.exe` or by adding the `--console` parameter. Windows doesn't really use stderr, so you need to read stdout. This fixes it, and tracebacks are appropriate reported.

I'm writing a guide to Love2D, and the first step in it is installing Atom and your love-ide package, so I'd love to help fix this so I can point people to it right away!