### PR TITLE
Update main.js to fix toolbar play icon display

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -147,7 +147,7 @@ export function consumeToolBar(toolBar: ToolBar) {
 
 	toolBarSection = toolBar('love-ide');
 	var runButton = toolBarSection.addButton({
-		icon: 'play',
+		icon: 'ios-play',
 		tooltip: 'Run Love App',
 		iconset: 'ion',
 		callback: run,


### PR DESCRIPTION
Ionicons now requires the ios- or md- prefix before the icon name. Without the prefix, the icon doesn't display.