### PR TITLE
Adding a 'Build' button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This package auto-installs several utilities for writing Love2D games in Atom. The individual packages can also be installed separately.
 
 - [Features](#features)
-  - [Run Icon in Toolbar](#run-icon-in-toolbar)
+  - [Run and Build Icon in Toolbar](#run-icon-in-toolbar)
   - [Love API Autocomplete](#love-api-autocomplete-via-autocomplete-lovehttpsatomiopackagesautocomplete-love)
   - [Love API Click to Definition](#love-api-click-to-definition-via-hyperclick-lovehttpsatomiopackageshyperclick-love)
   - [Lua Syntax Checking](#lua-syntax-checking-via-linter-luaparsehttpsatomiopackageslinter-luaparse)
@@ -13,10 +13,11 @@ This package auto-installs several utilities for writing Love2D games in Atom. T
 ## Features
 `love-ide` auto-installs packages that provide the following features.
 
-### Run Icon in Toolbar
+### Run and Build Icon in Toolbar
 ![](https://raw.githubusercontent.com/rameshvarun/love-ide/master/demo/run.png)
 
-Runs `love .` in the project directory. As of now, this can't be installed separately.
+The first runs `love .` in the project directory, the other one makes an .exe file (or a .love file if you're not using Windows).
+As of now, this can't be installed separately.
 
 ### Love API Autocomplete (via [autocomplete-love](https://atom.io/packages/autocomplete-love))
 ![](https://raw.githubusercontent.com/rameshvarun/love-ide/master/demo/autocomplete.png)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This package auto-installs several utilities for writing Love2D games in Atom. The individual packages can also be installed separately.
 
 - [Features](#features)
-  - [Run and Build Icon in Toolbar](#run-icon-in-toolbar)
+  - [Run and Build Icon in Toolbar](#run-and-build-icon-in-toolbar)
   - [Love API Autocomplete](#love-api-autocomplete-via-autocomplete-lovehttpsatomiopackagesautocomplete-love)
   - [Love API Click to Definition](#love-api-click-to-definition-via-hyperclick-lovehttpsatomiopackageshyperclick-love)
   - [Lua Syntax Checking](#lua-syntax-checking-via-linter-luaparsehttpsatomiopackageslinter-luaparse)

--- a/lib/build-love.bat
+++ b/lib/build-love.bat
@@ -15,7 +15,6 @@ echo Building...
 copy /by love.exe+compressed.zip "%CurrDirName%.exe"
 del /f compressed.zip
 del /f love.exe
-start explorer.exe .
 goto :end
 
 :searchInEnVar

--- a/lib/build-love.bat
+++ b/lib/build-love.bat
@@ -41,7 +41,9 @@ goto :end
 
 :usage
 echo Error: missing argument.
-echo USAGE: %~nx0 TargetDirectory [love.exe path]
+echo USAGE: %~nx0 ProjectDirectory [love.exe]
+echo.
+echo If the love.exe path is missing from the arguments it will be searched in the PATH environment variable.
 pause
 
 :end

--- a/lib/build-love.bat
+++ b/lib/build-love.bat
@@ -1,0 +1,48 @@
+@echo off
+if [%1]==[] goto usage
+cd %1
+powershell Compress-Archive * compressed.zip
+set lovepath=%2
+IF [%lovepath%]==[] ( goto :searchInEnVar )
+IF ["%lovepath%"]==["love"] ( goto :searchInEnVar )
+IF ["%lovepath%"]==["love.exe"] ( goto :searchInEnVar )
+IF NOT EXIST "%2" ( goto :searchInEnVar )
+
+:build
+copy %lovepath% .
+for %%I in (.) do set CurrDirName=%%~nxI
+echo Building...
+copy /by love.exe+compressed.zip "%CurrDirName%.exe"
+del /f compressed.zip
+del /f love.exe
+start explorer.exe .
+goto :end
+
+:searchInEnVar
+echo Searching for love.exe in the environment variables...
+for %%a in ("%PATH:;=" "%") do (
+	Echo.%%a | findstr /C:"LOVE">nul && (
+		pushd %%a
+		IF EXIST "love.exe" (
+			Echo.Found on %%a
+			set lovepath=%%a\love.exe
+			popd
+			goto :build
+		)
+		popd
+		Echo.Still searching...
+	) || (
+    		Echo.Still searching...
+	)
+)
+Echo.Cannot find love.exe
+pause
+goto :end
+
+:usage
+echo Error: missing argument.
+echo USAGE: %~nx0 TargetDirectory [love.exe path]
+pause
+
+:end
+exit

--- a/lib/main.js
+++ b/lib/main.js
@@ -35,8 +35,8 @@ directory as the current working directory.`,
 		order: 3,
 	},
 	disableToolbarButton: {
-		title: 'Disable Toolbar Button',
-		description: `Don't show a run icon in the toolbar.`,
+		title: 'Disable Toolbar Buttons',
+		description: `Don't show a run and a build icon in the toolbar.`,
 		type: 'boolean',
 		default: false,
 		order: 4,
@@ -204,9 +204,12 @@ export function consumeToolBar(toolBar: ToolBar) {
 		callback: run,
 	});
 
+	var buildTooltip = 'Create a .love-file';
+	if (process.platform == "win32") { buildTooltip = 'Build Love Windows Executable'; }
+
 	var buildButton = toolBarSection.addButton({
 		icon: 'ios-hammer',
-		tooltip: 'Build Love App',
+		tooltip: buildTooltip,
 		iconset: 'ion',
 		callback: buildapp,
 	});

--- a/lib/main.js
+++ b/lib/main.js
@@ -68,21 +68,20 @@ function buildapp() {
 
 	var lovePath = atom.config.get('love-ide.lovePath') || 'love';
 
-	// Get package directory
-	var startpath = atom.packages.getPackageDirPaths()[0] + "\\love-ide\\lib";
-	for (var lipath of atom.packages.getPackageDirPaths()) {
-		if (fs.existsSync(lipath + "\\love-ide\\lib")) {
-			startpath = lipath + "\\love-ide\\lib";
-		}
-	}
+	var startpath = dirs[0].getPath();
+	var command = "zip -9 -r compressed.love .";
 
 	// Check OS
-	var command = "zip -9 -r compressed.love .";
 	if (process.platform == "win32") {
+		// Get package directory
+		for (var lipath of atom.packages.getPackageDirPaths()) {
+			if (fs.existsSync(lipath + "\\love-ide\\lib")) {
+				startpath = lipath + "\\love-ide\\lib";
+			}
+		}
+
+		// Start CMD and run build-love.bat
 		command = `start cmd.exe @cmd /c "start build-love.bat ${dirs[0].getPath()} ${lovePath} && exit"`;
-	}
-	else {
-		startpath = dirs[0].getPath();
 	}
 
 	// Run commands
@@ -190,7 +189,7 @@ function run() {
 }
 
 atom.commands.add('atom-text-editor', 'love-ide:run-love', run);
-atom.commands.add('atom-text-editor', 'love-ide:compile-love', buildapp);
+atom.commands.add('atom-text-editor', 'love-ide:build-love', buildapp);
 
 var toolBarSection = null;
 export function consumeToolBar(toolBar: ToolBar) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,6 +47,56 @@ export function activate () {
 	require('atom-package-deps').install('love-ide');
 }
 
+function buildapp() {
+	// Find all the directories that have a main.lua in them.
+	var dirs = atom.project.getDirectories().filter(dir =>
+		dir.getFile('main.lua').existsSync());
+
+	// No directories were found.
+	if(dirs.length == 0) {
+		atom.notifications.addError("None of the project directories have a main.lua");
+		return;
+	}
+
+	// Prioritize the directory of the currently active editor.
+	const activeEditor = atom.workspace.getActiveTextEditor();
+	dirs.sort((a, b) => {
+		if (a.contains(activeEditor.getPath())) return -1;
+		if (b.contains(activeEditor.getPath())) return 1;
+		else return 0;
+	});
+
+	var lovePath = atom.config.get('love-ide.lovePath') || 'love';
+
+	// Get package directory
+	var startpath = atom.packages.getPackageDirPaths()[0] + "\\love-ide\\lib";
+	for (var lipath of atom.packages.getPackageDirPaths()) {
+		if (fs.existsSync(lipath + "\\love-ide\\lib")) {
+			startpath = lipath + "\\love-ide\\lib";
+		}
+	}
+
+	// Check OS
+	var command = "zip -9 -r compressed.love .";
+	if (process.platform == "win32") {
+		command = `start cmd.exe @cmd /c "start build-love.bat ${dirs[0].getPath()} ${lovePath} && exit"`;
+	}
+	else {
+		startpath = dirs[0].getPath();
+	}
+
+	// Run commands
+	child_process.exec(command, {cwd: startpath}, (err, stdout, stderr) => {
+		if(err) {
+			var message = stderr.toString();
+			if (err.code == 127) message = "LOVE executable not found. Try setting the PATH in the love-ide settings menu.";
+			atom.notifications.addError('Error running LOVE.', {
+				detail: message
+			});
+		}
+	});
+}
+
 function run() {
 	// Find all the directories that have a main.lua in them.
 	var dirs = atom.project.getDirectories().filter(dir =>
@@ -140,6 +190,7 @@ function run() {
 }
 
 atom.commands.add('atom-text-editor', 'love-ide:run-love', run);
+atom.commands.add('atom-text-editor', 'love-ide:compile-love', buildapp);
 
 var toolBarSection = null;
 export function consumeToolBar(toolBar: ToolBar) {
@@ -151,6 +202,13 @@ export function consumeToolBar(toolBar: ToolBar) {
 		tooltip: 'Run Love App',
 		iconset: 'ion',
 		callback: run,
+	});
+
+	var buildButton = toolBarSection.addButton({
+		icon: 'ios-hammer',
+		tooltip: 'Build Love App',
+		iconset: 'ion',
+		callback: buildapp,
 	});
 }
 


### PR DESCRIPTION
These commits add a build button that

1. Builds an executable if you're using Atom on Windows (through external batch file).
2. Makes a .love file if you're using Atom on another platform

Maybe I'll add the possibility to build MacOS apps in the future

---

![windows](https://user-images.githubusercontent.com/38359416/92469791-b417ad00-f1d5-11ea-8124-08ce35469a15.png)

![ubuntu](https://user-images.githubusercontent.com/38359416/92469805-b974f780-f1d5-11ea-8764-65d10cbe74cc.png)
